### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,30 @@
-$(function(){ 
+$(function(){
+  var reloadMessages = function() {
+    var last_message_id = $('.main-chat__message-list__massage:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+      var insertHTML = '';
+      $.each(messages, function(i, message) {
+        insertHTML += buildHTML(message)
+      });
+      $('.main-chat__message-list').append(insertHTML);
+      $('.main-chat__message-list:last').animate({ scrollTop: $('.main-chat__message-list:last')[0].scrollHeight});
+    }
+    })
+    .fail(function() {
+      alert('error');
+    });
+  };
   function buildHTML(message){
    if ( message.image ) {
      var html =
-      `<div class="main-chat__message-list__massage">
+      `<div class="main-chat__message-list__massage" data-message-id=` + message.id + `>
          <div class="main-chat__message-list__massage__name-datetime">
            <div class="main-chat__message-list__massage__name-datetime__name">
              ${message.user_name}
@@ -17,11 +39,12 @@ $(function(){
            </div>
          </div>
          <img src=${message.image} >
+         </div>
        </div>`
      return html;
    } else {
      var html =
-      `<div class="main-chat__message-list__massage">
+      `<div class="main-chat__message-list__massage" data-message-id=` + message.id + `>
          <div class="main-chat__message-list__massage__name-datetime">
            <div class="main-chat__message-list__massage__name-datetime__name">
              ${message.user_name}
@@ -62,4 +85,7 @@ $('#new_message').on('submit', function(e){
     alert('メッセージ送信に失敗しました');
   })
 })
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main-chat__message-list__massage
+.main-chat__message-list__massage{data: {message: {id: message.id}}}
   .main-chat__message-list__massage__name-datetime
     .main-chat__message-list__massage__name-datetime__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
+json.content    @message.content
+json.image      @message.image.url
 json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-json.content @message.content
-json.image @message.image_url
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end


### PR DESCRIPTION
# What
* チャット画面の自動更新を実装
* 自動更新時、画面が最下部までスクロールされる
* テキスト/画像ともに自動更新される
* 自動更新が他のグループに影響しない

# Why
毎回リロードしなくても相手からのメッセージが表示されるようになり、
ユーザが快適にアプリを利用できるため。

![chat-space2](https://user-images.githubusercontent.com/62428120/77899621-e08add00-72b7-11ea-83c1-a1060df43b36.gif)
